### PR TITLE
Fix typo: Change CATALIA_HOME to CATALINA_HOME in documentation

### DIFF
--- a/webapps/docs/introduction.xml
+++ b/webapps/docs/introduction.xml
@@ -115,7 +115,7 @@ do let us know.</p>
         instances with single CATALINA_HOME location share one set of
         <code>.jar</code> files and binary files, you can easily upgrade the files
         to newer version and have the change propagated to all Tomcat instances
-        using the same CATALIA_HOME directory.
+        using the same CATALINA_HOME directory.
       </li>
       <li>
         Avoiding duplication of the same static <code>.jar</code> files.


### PR DESCRIPTION
- Fixed spelling error on line 118 of introduction documentation
- CATALIA_HOME -> CATALINA_HOME (added missing 'N')
- Ensures consistency with correct environment variable name